### PR TITLE
Add support for handlebar helpers functions

### DIFF
--- a/scripts/export-markdown.js
+++ b/scripts/export-markdown.js
@@ -158,10 +158,47 @@ function notefilename(doc) {
 
 let turndownService, gfm;
 
-async function convertLinks(markdown, relativeTo) {
+// This is function is used in pf2e-md-exporter as a part of removing async functions used in handlebar helpers.
+function uuidFailSafe(target, label) {
+    if (!use_uuid_for_notename) {
+        // Foundry's fromUuidSync() will thrown an error if the UUID 
+        // document is only available via an async operation.
+        // We can't resolve async function calls via a handlebar, so let's try another approach...
+        
+        // I discovered this function mentioned in foundry.js:
+        // let {collection, documentId, documentType, embedded, doc} = foundry.utils.parseUuid(target);
+
+        // Get the UUID parts for the target - that can always be done synchronously.
+        let uuidParts = foundry.utils.parseUuid(target);
+
+        // Using the UUID parts information from the target, get the UUID of the target's parent
+        let parentUuid = uuidParts.collection.getUuid(uuidParts.documentId);
+        
+        // Now that we have the parent's UUID, get it in document form.
+        // In testing, it appears the parent can be fetched via a synchronoous operation, which is what we need.
+        let parentDoc = fromUuidSync(parentUuid);
+
+        if (parentDoc) {
+            // Lookup the friendly name of the path, so we can use it as a prefix for the link to make it more unique.
+            let pack = game.packs.get(parentDoc.pack);
+            if (pack) {
+                // Slashes in the title aren't real paths and as part of the export become underscores
+                let fixed_title = pack.title.replaceAll('/', '_');
+                let result = `${fixed_title}/${parentDoc.name}/${label}`;
+                //console.log("Resolved URL:", result);
+                return formatLink(result, label, /*inline*/false);
+            }
+        }
+        console.log("Ooops.... we fell through.  Unresolved URL: ", target);
+    }
+    return dummyLink(target, label);
+}
+
+
+function convertLinks(markdown, relativeTo) {
 
     // Needs to be nested so that we have access to 'relativeTo'
-    async function replaceOneLink(str, type, target, hash, label, offset, string, groups) {
+    function replaceOneLink(str, type, target, hash, label, offset, string, groups) {
 
         // One of my Foundry Modules introduced adding "inline" to the start of type.
         let inline = type.startsWith("inline");
@@ -182,11 +219,11 @@ async function convertLinks(markdown, relativeTo) {
 
         let linkdoc;
         try {
-            linkdoc = await fromUuid(target, {relative: relativeTo});
+            linkdoc = fromUuidSync(target, {relative: relativeTo});
             if (!label && !hash) label = doc.name;
         } catch (error) {
-            console.debug(`Unable to fetch label from Compendium for ${target}`, error)
-            return dummyLink();
+            //console.debug(`Unable to fetch label from Compendium for ${target}`, error)
+            return uuidFailSafe(target, label);
         }
 
         if (!linkdoc) return dummyLink();
@@ -209,14 +246,14 @@ async function convertLinks(markdown, relativeTo) {
     
     // Convert all the links
     const pattern = /@([A-Za-z]+)\[([^#\]]+)(?:#([^\]]+))?](?:{([^}]+)})?/g;
-    markdown = await replaceAsync(markdown, pattern, replaceOneLink);
+    markdown = markdown.replace(pattern, replaceOneLink);
     // Replace file references (TBD AFTER HTML conversion)
     const filepattern = /!\[\]\(([^)]*)\)/g;
     markdown = markdown.replaceAll(filepattern, replaceLinkedFile);
     return markdown;
 }
 
-export async function convertHtml(doc, html) {
+export function convertHtml(doc, html) {
     // Foundry uses "showdown" rather than "turndown":
     // SHOWDOWN fails to parse tables at all
 
@@ -235,7 +272,7 @@ export async function convertHtml(doc, html) {
     try {
         // Convert links BEFORE doing HTML->MARKDOWN (to get links inside tables working properly)
         // The conversion "escapes" the "[[...]]" markers, so we have to remove those markers afterwards
-        markdown = turndownService.turndown((await convertLinks(html, doc))).replaceAll("\\[\\[","[[").replaceAll("\\]\\]","]]");
+        markdown = turndownService.turndown((convertLinks(html, doc))).replaceAll("\\[\\[","[[").replaceAll("\\]\\]","]]");
         // Now convert file references
         const filepattern = /!\[\]\(([^)]*)\)/g;
         markdown = markdown.replaceAll(filepattern, replaceLinkedFile);    
@@ -310,7 +347,7 @@ async function oneRollTable(path, table) {
     for (const tableresult of table.results) {
         const range  = (tableresult.range[0] == tableresult.range[1]) ? tableresult.range[0] : `${tableresult.range[0]}-${tableresult.range[1]}`;
         // Escape the "|" in any links
-        markdown += `| ${range} | ${(await convertLinks(tableresult.getChatText(), table)).replaceAll("|","\\|")} |\n`;
+        markdown += `| ${range} | ${(convertLinks(tableresult.getChatText(), table)).replaceAll("|","\\|")} |\n`;
     }
 
     // No path for tables
@@ -453,7 +490,7 @@ async function documentToJSON(path, doc) {
     // TODO: maybe extract Items as separate notes?
 
     // Convert LINKS: Foundry syntax to Markdown syntax
-    datastring = await convertLinks(datastring, doc);
+    datastring = convertLinks(datastring, doc);
 
     markdown +=
         MARKER + doc.documentName + EOL + 

--- a/scripts/export-markdown.js
+++ b/scripts/export-markdown.js
@@ -5,7 +5,6 @@ import "./lib/js-yaml.min.js";
 import replaceAsync from "./lib/string-replace-async.js";
 import * as MOD_CONFIG from "./config.js";
 import { myRenderTemplate, clearTemplateCache } from "./render-template.js"
-import { registerHandlebarsHelpers } from "handlebar-helpers.js"
 
 const MODULE_NAME = "export-markdown";
 const FRONTMATTER = "---\n";
@@ -51,7 +50,7 @@ class DOCUMENT_ICON {
  * @param {Object} from Either a folder or a Journal, selected from the sidebar
  */
 
-function validFilename(name) {
+export function validFilename(name) {
     const regexp = /[<>:"/\\|?*]/g;
     return name.replaceAll(regexp, '_');
 }
@@ -110,7 +109,7 @@ function formatLink(link, label=null, inline=false) {
     return result;
 }
 
-function fileconvert(filename, label_or_size=null, inline=true) {
+export function fileconvert(filename, label_or_size=null, inline=true) {
     filename = decodeURIComponent(filename);
     //let basefilename = filename.slice(filename.lastIndexOf("/") + 1);
     // ensure same base filename in different paths are stored as different files,
@@ -211,15 +210,13 @@ async function convertLinks(markdown, relativeTo) {
     // Convert all the links
     const pattern = /@([A-Za-z]+)\[([^#\]]+)(?:#([^\]]+))?](?:{([^}]+)})?/g;
     markdown = await replaceAsync(markdown, pattern, replaceOneLink);
-    
     // Replace file references (TBD AFTER HTML conversion)
     const filepattern = /!\[\]\(([^)]*)\)/g;
     markdown = markdown.replaceAll(filepattern, replaceLinkedFile);
-
     return markdown;
 }
 
-async function convertHtml(doc, html) {
+export async function convertHtml(doc, html) {
     // Foundry uses "showdown" rather than "turndown":
     // SHOWDOWN fails to parse tables at all
 
@@ -245,7 +242,6 @@ async function convertHtml(doc, html) {
     } catch (error) {
         console.warn(`Error: failed to decode html:`, html)
     }
-
     return markdown;
 }
 
@@ -283,7 +279,7 @@ async function oneJournal(path, journal) {
             case "text":
                 switch (page.text.format) {
                     case 1: // HTML
-                        markdown = await convertHtml(page, page.text.content);
+                        markdown = convertHtml(page, page.text.content);
                         break;
                     case 2: // MARKDOWN
                         markdown = page.text.markdown;
@@ -443,7 +439,7 @@ async function documentToJSON(path, doc) {
     ]
     for (const field of DESCRIPTIONS) {
         let text = foundry.utils.getProperty(doc, field);
-        if (text) markdown += await convertHtml(doc, text) + EOL + EOL;
+        if (text) markdown += convertHtml(doc, text) + EOL + EOL;
     }
 
     let datastring;
@@ -510,7 +506,7 @@ async function oneChatMessage(path, message) {
     if (!html?.length) return message.export();
 
     return `## ${new Date(message.timestamp).toLocaleString()}\n\n` + 
-        await convertHtml(message, html[0].outerHTML);
+        convertHtml(message, html[0].outerHTML);
 }
 
 async function oneChatLog(path, chatlog) {

--- a/scripts/export-markdown.js
+++ b/scripts/export-markdown.js
@@ -5,6 +5,7 @@ import "./lib/js-yaml.min.js";
 import replaceAsync from "./lib/string-replace-async.js";
 import * as MOD_CONFIG from "./config.js";
 import { myRenderTemplate, clearTemplateCache } from "./render-template.js"
+import { registerHandlebarsHelpers } from "handlebar-helpers.js"
 
 const MODULE_NAME = "export-markdown";
 const FRONTMATTER = "---\n";

--- a/scripts/handlebar-helpers.js
+++ b/scripts/handlebar-helpers.js
@@ -1,0 +1,14 @@
+import * from "export-markdown.js";
+
+Handlebars.registerHelper('validFileName', function (name) {
+        return validFilename(name);
+    });
+
+Handlebars.registerHelper('convertHtml', function (doc, html) {
+        return validFilename(name);
+    });
+
+
+Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
+        return validFilename(name);
+    });

--- a/scripts/handlebar-helpers.js
+++ b/scripts/handlebar-helpers.js
@@ -1,17 +1,36 @@
-//import * from "export-markdown.js";
+import { /*validFileName,*/ convertHtml, fileconvert } from "./export-markdown.js";
 
 export const registerHandlebarsHelpers = function () {
-
-        Handlebars.registerHelper('validFileName', function (name) {
+    
+    //Handlebar Helpers
+    
+    // Escapes file names to make them valid
+    Handlebars.registerHelper('validFileName', function (name) {
                 return validFilename(name);
             });
 
-        Handlebars.registerHelper('convertHtml', function (doc, html) {
-                return validFilename(name);
-            });
+    // Convert HTML to Markdown
+    Handlebars.registerHelper('convertHtml', function (context, text) {
+        if (text) {
+            text = convertHtml(context, text);
+        }
+        return text;
+        });
 
 
-        Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
-                return validFilename(name);
-            });
+    // Converts an image file reference to a wikilinks Markdown format
+    Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
+            return fileconvert(filename, label_or_size);
+        });
+
+    // Retrieves the items of a given type
+    Handlebars.registerHelper('itemsOfType', function (items, type) {
+        let _itemsOfType = [];
+        for (let item of items) {
+            if(item.type === type) {
+                _itemsOfType.push(item);
+            }
+        }
+        return _itemsOfType;
+    });
 }

--- a/scripts/handlebar-helpers.js
+++ b/scripts/handlebar-helpers.js
@@ -4,10 +4,12 @@ export const registerHandlebarsHelpers = function () {
     
     //Handlebar Helpers
     
+    /*  IMPORT OF THE FUNCTION BREAKS THE MODULE SETTINGS.
     // Escapes file names to make them valid
     Handlebars.registerHelper('validFileName', function (name) {
                 return validFilename(name);
             });
+            */
 
     // Convert HTML to Markdown
     Handlebars.registerHelper('convertHtml', function (context, text) {

--- a/scripts/handlebar-helpers.js
+++ b/scripts/handlebar-helpers.js
@@ -1,14 +1,17 @@
-import * from "export-markdown.js";
+//import * from "export-markdown.js";
 
-Handlebars.registerHelper('validFileName', function (name) {
-        return validFilename(name);
-    });
+export const registerHandlebarsHelpers = function () {
 
-Handlebars.registerHelper('convertHtml', function (doc, html) {
-        return validFilename(name);
-    });
+        Handlebars.registerHelper('validFileName', function (name) {
+                return validFilename(name);
+            });
+
+        Handlebars.registerHelper('convertHtml', function (doc, html) {
+                return validFilename(name);
+            });
 
 
-Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
-        return validFilename(name);
-    });
+        Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
+                return validFilename(name);
+            });
+}

--- a/scripts/module-settings.js
+++ b/scripts/module-settings.js
@@ -1,5 +1,6 @@
 import * as MOD_CONFIG from "./config.js";
 import { /*validFileName,*/ convertHtml, fileconvert } from "./export-markdown.js";
+//import { registerHandlebarsHelpers } from "./handlebar-helpers.js"
 
 /*
  * MODULE OPTIONS
@@ -95,6 +96,8 @@ Hooks.once('ready', () => {
             filePicker: "text"
         })
     }
+
+    //registerHandlebarsHelpers();
 
     //Handlebar Helpers
     Handlebars.registerHelper('validFileName', function (name) {

--- a/scripts/module-settings.js
+++ b/scripts/module-settings.js
@@ -1,6 +1,5 @@
 import * as MOD_CONFIG from "./config.js";
-import { /*validFileName,*/ convertHtml, fileconvert } from "./export-markdown.js";
-//import { registerHandlebarsHelpers } from "./handlebar-helpers.js"
+import { registerHandlebarsHelpers } from "./handlebar-helpers.js"
 
 /*
  * MODULE OPTIONS
@@ -97,34 +96,9 @@ Hooks.once('ready', () => {
         })
     }
 
-    //registerHandlebarsHelpers();
+    // Register Handle Bar Helpers
+    registerHandlebarsHelpers();
 
-    //Handlebar Helpers
-    Handlebars.registerHelper('validFileName', function (name) {
-                return validFilename(name);
-            });
-
-    Handlebars.registerHelper('convertHtml', function (context, text) {
-        if (text) {
-            text = convertHtml(context, text);
-        }
-        return text;
-        });
-
-
-    Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
-            return fileconvert(filename, label_or_size);
-        });
-
-    Handlebars.registerHelper('itemsOfType', function (items, type) {
-        let _itemsOfType = [];
-        for (let item of items) {
-            if(item.type === type) {
-                _itemsOfType.push(item);
-            }
-        }
-        return _itemsOfType;
-    });
 })
 // End Hook Once
 

--- a/scripts/module-settings.js
+++ b/scripts/module-settings.js
@@ -1,4 +1,5 @@
-import * as MOD_CONFIG from "./config.js"
+import * as MOD_CONFIG from "./config.js";
+import { /*validFileName,*/ convertHtml, fileconvert } from "./export-markdown.js";
 
 /*
  * MODULE OPTIONS
@@ -94,7 +95,26 @@ Hooks.once('ready', () => {
             filePicker: "text"
         })
     }
+
+    //Handlebar Helpers
+    Handlebars.registerHelper('validFileName', function (name) {
+                return validFilename(name);
+            });
+
+    Handlebars.registerHelper('convertHtml', async function (context, text) {
+        if (text) {
+            text = await convertHtml(context, text);
+        }
+        console.log("text -> " + text);
+        return text;
+        });
+
+
+    Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
+            return fileconvert(filename, label_or_size);
+        });
 })
+// End Hook Once
 
 // Add headers for the Actor and Item settings
 Hooks.on('renderSettingsConfig', (app, html, options) => {

--- a/scripts/module-settings.js
+++ b/scripts/module-settings.js
@@ -101,11 +101,10 @@ Hooks.once('ready', () => {
                 return validFilename(name);
             });
 
-    Handlebars.registerHelper('convertHtml', async function (context, text) {
+    Handlebars.registerHelper('convertHtml', function (context, text) {
         if (text) {
-            text = await convertHtml(context, text);
+            text = convertHtml(context, text);
         }
-        console.log("text -> " + text);
         return text;
         });
 
@@ -113,6 +112,16 @@ Hooks.once('ready', () => {
     Handlebars.registerHelper('fileconvert', function (filename, label_or_size) {
             return fileconvert(filename, label_or_size);
         });
+
+    Handlebars.registerHelper('itemsOfType', function (items, type) {
+        let _itemsOfType = [];
+        for (let item of items) {
+            if(item.type === type) {
+                _itemsOfType.push(item);
+            }
+        }
+        return _itemsOfType;
+    });
 })
 // End Hook Once
 


### PR DESCRIPTION
Added a new file for Handlebar Helper functions including functions for converting HTML to Markdown, retrieving arrays of types of items for use in Handlebar templates, and function for properly linking images in Markdown.  Modifications to existing functions include removing async and await from the functions used by the Helper functions because Handlebars Helpers do not support async functions.